### PR TITLE
Resolution for issue where the cache table didnt have the data

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2,7 +2,7 @@
 buildscript {
     ext {
         kotlin_version = '1.8.0'
-        versionName = '0.0.24'
+        versionName = '0.0.27'
     }
 
     repositories {

--- a/lib/src/main/java/com/evdayapps/madassistant/clientlib/connection/ConnectionManagerImpl.kt
+++ b/lib/src/main/java/com/evdayapps/madassistant/clientlib/connection/ConnectionManagerImpl.kt
@@ -26,13 +26,13 @@ class ConnectionManagerImpl(
 ) : ConnectionManager, ServiceConnection, MADAssistantClientAIDL.Stub() {
 
     companion object {
-        const val TAG = "MADAssist:ConnectionManagerImpl"
-
         const val REPO_SERVICE_PACKAGE = "com.evdayapps.madassistant.repository"
         const val REPO_SERVICE_CLASS = "$REPO_SERVICE_PACKAGE.service.MADAssistantService"
         const val DEFAULT_REPO_SIGNATURE = "1B:C0:79:26:82:9E:FB:96:5C:6A:51:6C:96:7C:52:88:42:" +
                 "7E:73:8C:05:7D:60:D8:13:9D:C4:3C:18:3B:E3:63"
     }
+
+    private val TAG = "MADAssist:ConnectionManagerImpl"
 
     private var currentState: ConnectionManager.State = ConnectionManager.State.None
 
@@ -237,12 +237,8 @@ class ConnectionManagerImpl(
         }
 
         when (errorMessage) {
-            null -> {
-                setConnectionState(ConnectionManager.State.Connected)
-            }
-            else -> {
-                disconnect(code = 401, message = "AuthToken Failed")
-            }
+            null -> setConnectionState(ConnectionManager.State.Connected)
+            else -> disconnect(code = 401, message = "AuthToken Failed")
         }
     }
     // endregion Handshake


### PR DESCRIPTION
Possible cause:
Key clash cause of key gen method "$type:$timestamp"
This avoids the cache table, which should never have been used tbh